### PR TITLE
process placed bets command

### DIFF
--- a/app/Console/Commands/DetermineEventOutcome.php
+++ b/app/Console/Commands/DetermineEventOutcome.php
@@ -2,7 +2,17 @@
 
 namespace App\Console\Commands;
 
+use App\Enums\BetType;
+use App\Enums\Outcome;
+use App\Enums\Sport;
+use App\Http\Integrations\TheOddsApi\Requests\ScoresRequest;
+use App\Http\Integrations\TheOddsApi\TheOddsApiConnector;
+use App\Models\Bet;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Throwable;
+
+use function Laravel\Prompts\spin;
 
 class DetermineEventOutcome extends Command
 {
@@ -11,7 +21,7 @@ class DetermineEventOutcome extends Command
      *
      * @var string
      */
-    protected $signature = 'app:determine-event-outcome';
+    protected $signature = 'app:determine-event-outcome {sport}';
 
     /**
      * The console command description.
@@ -23,5 +33,81 @@ class DetermineEventOutcome extends Command
     /**
      * Execute the console command.
      */
-    public function handle() {}
+    public function handle()
+    {
+        $sport = Sport::tryFrom($this->argument('sport'));
+
+        if (! $sport) {
+            $this->error("{$this->argument('sport')} is not a valid sport");
+
+            return 1;
+        }
+
+        $bets = Bet::query()
+            ->where('sport', $sport)
+            ->whereNull('outcome')
+            ->get()
+            ->groupBy('event_id');
+
+        $eventIds = $bets->pluck('event_id')->unique();
+
+        try {
+            $events = spin(fn () => $this->fetchEventScores($sport, $eventIds), 'fetching scores');
+        } catch (Throwable $e) {
+            $this->error('Failed to fetch scores: '.$e->getMessage());
+
+            return 1;
+        }
+
+        $events->each(function ($scores, $event) use ($bets) {
+            $firstTeam = $scores->first();
+            $secondTeam = $scores->last();
+
+            $highestScoringTeam = $firstTeam === $secondTeam
+                ? null
+                : $scores->sortDesc()->keys()->first();
+
+            $eventScoreTotal = $scores->sum();
+
+            $eventBets = $bets->get($event);
+
+            $eventBets?->each(function ($bet) use ($highestScoringTeam, $eventScoreTotal) {
+                if ($highestScoringTeam) {
+                    if ($bet->bet_type === BetType::Favorite || $bet->bet_type === BetType::Dawg) {
+                        $won = $bet->team_id === $highestScoringTeam;
+
+                        $this->setOutcome($bet, $won);
+                    }
+                } else {
+                    $bet->outcome = Outcome::Draw;
+                }
+
+                if ($bet->bet_type === BetType::Under) {
+                    $won = $bet->over_under < $eventScoreTotal;
+
+                    $this->setOutcome($bet, $won);
+                }
+
+                if ($bet->bet_type === BetType::Over) {
+                    $won = $bet->over_under > $eventScoreTotal;
+
+                    $this->setOutcome($bet, $won);
+                }
+
+                $bet->save();
+            });
+        });
+    }
+
+    protected function fetchEventScores(Sport $sport, Collection $eventIds)
+    {
+        return app(TheOddsApiConnector::class)
+            ->send(new ScoresRequest($sport, $eventIds))
+            ->dto();
+    }
+
+    protected function setOutcome($bet, $won): void
+    {
+        $bet->outcome = $won ? Outcome::Win : Outcome::Lose;
+    }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -34,7 +34,7 @@ class DashboardController extends Controller
                         'user' => $user->name,
                         'user_id' => $bet->user_id,
                         'team_name' => $bet->team->team_name,
-                        'bet_placed_at' =>  $bet->created_at->setTimezone('America/New_York')->format('m/d/Y g:ia'),
+                        'bet_placed_at' => $bet->created_at->setTimezone('America/New_York')->format('m/d/Y g:ia'),
                         'outcome' => $bet->outcome?->label() ?? 'No Outcome Yet',
                         'sport' => $bet->sport->label(),
                         'bet_type' => $bet->bet_type->label(),

--- a/app/Http/Controllers/FootballController.php
+++ b/app/Http/Controllers/FootballController.php
@@ -17,7 +17,7 @@ class FootballController extends Controller
             ->where('sport', Sport::Football)
             ->whereBetween('created_at', [
                 Carbon::now()->startOfWeek(WeekDay::Thursday),
-                Carbon::now()->endOfWeek(WeekDay::Tuesday)
+                Carbon::now()->endOfWeek(WeekDay::Tuesday),
             ])
             ->get();
 

--- a/app/Http/Integrations/TheOddsApi/Requests/OddsRequest.php
+++ b/app/Http/Integrations/TheOddsApi/Requests/OddsRequest.php
@@ -41,9 +41,33 @@ class OddsRequest extends Request implements Cacheable
 
     protected function defaultQuery(): array
     {
-        $commenceTimeFrom = Carbon::now()->startOfWeek(WeekDay::Thursday)->toIso8601ZuluString();
+        $now = Carbon::now();
 
-        $commenceTimeTo = Carbon::now()->endOfWeek(WeekDay::Tuesday)->toIso8601ZuluString();
+        $isSunday = $now->copy()
+            ->tz('America/New_York')
+            ->isDayOfWeek(WeekDay::Sunday->value);
+
+        if ($isSunday) {
+            $commenceTimeFrom = $now->copy()
+                ->startOfWeek(WeekDay::Sunday)
+                ->startOfDay()
+                ->toIso8601ZuluString();
+
+            $commenceTimeTo = $now->copy()
+                ->startOfWeek(WeekDay::Sunday)
+                ->endOfDay()
+                ->toIso8601ZuluString();
+        } else {
+            $commenceTimeFrom = $now->copy()
+                ->endOfWeek(WeekDay::Sunday)
+                ->startOfDay()
+                ->toIso8601ZuluString();
+
+            $commenceTimeTo = $now->copy()
+                ->endOfWeek(WeekDay::Sunday)
+                ->endOfDay()
+                ->toIso8601ZuluString();
+        }
 
         return [
             'regions' => 'us',
@@ -51,7 +75,7 @@ class OddsRequest extends Request implements Cacheable
             'oddsFormat' => 'american',
             'bookmakers' => 'draftkings',
             'commenceTimeFrom' => $commenceTimeFrom,
-            'commenceTimeTo' => $commenceTimeTo
+            'commenceTimeTo' => $commenceTimeTo,
         ];
     }
 

--- a/app/Http/Requests/PlaceBetRequest.php
+++ b/app/Http/Requests/PlaceBetRequest.php
@@ -16,6 +16,7 @@ class PlaceBetRequest extends FormRequest
             'team_id' => ['required', 'integer', 'exists:teams,id'],
             'bet_type' => ['required', 'string', Rule::enum(BetType::class)],
             'sport' => ['required', 'string', Rule::enum(Sport::class)],
+            'over_under' => ['nullable', 'numeric'],
         ];
     }
 }

--- a/app/Models/Bet.php
+++ b/app/Models/Bet.php
@@ -31,6 +31,7 @@ class Bet extends Model
         'outcome',
         'bet_type',
         'sport',
+        'over_under',
     ];
 
     /**
@@ -43,6 +44,7 @@ class Bet extends Model
         'outcome' => Outcome::class,
         'bet_type' => BetType::class,
         'sport' => Sport::class,
+        'over_under' => 'decimal:2',
     ];
 
     /*

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -62,7 +62,7 @@ class User extends Authenticatable implements FilamentUser
 
     public function canAccessPanel(Panel $panel): bool
     {
-        return (bool)Auth::user()->is_admin;
+        return (bool) Auth::user()->is_admin;
     }
 
     /*

--- a/database/migrations/2025_09_10_014859_add_over_under_to_bets.php
+++ b/database/migrations/2025_09_10_014859_add_over_under_to_bets.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('bets', 'over_under')) {
+            Schema::table('bets', function (Blueprint $table) {
+                $table->decimal('over_under')->nullable();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('bets', 'over_under')) {
+            Schema::table('bets', function (Blueprint $table) {
+                $table->dropColumn('over_under');
+            });
+        }
+    }
+};

--- a/resources/js/Components/Bet/BetButton.vue
+++ b/resources/js/Components/Bet/BetButton.vue
@@ -17,6 +17,11 @@ const props = defineProps({
         type: String,
         default: null,
     },
+    overUnder: {
+        type: Number,
+        default: null,
+        required: false,
+    },
 });
 
 // Checks if THIS specific bet has been selected in the pending slip
@@ -50,6 +55,7 @@ function handleBetSelection() {
         event_id: props.eventId,
         team_id: props.teamId,
         bet_type: props.betType,
+        over_under: props.overUnder,
     };
     store.toggleBetInSlip(betDetails);
 }

--- a/resources/js/Components/Bet/TeamBet.vue
+++ b/resources/js/Components/Bet/TeamBet.vue
@@ -29,6 +29,7 @@ defineProps({
                 :bet-type="team.total.type"
                 :team-id="team.id"
                 :event-id="eventId"
+                :over-under="team.total.point"
             >
                 <p>
                     {{ team.total.type.charAt(0).toUpperCase() }}

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -121,7 +121,8 @@ window.addEventListener('resize', () => {
                                 <DropdownLink :href="route('profile.edit')">
                                     Profile
                                 </DropdownLink>
-                                <DropdownLink v-if="usePage().props.auth.admin"
+                                <DropdownLink
+                                    v-if="usePage().props.auth.admin"
                                     :href="
                                         route('filament.admin.pages.dashboard')
                                     "

--- a/resources/js/Pages/Football/Index.vue
+++ b/resources/js/Pages/Football/Index.vue
@@ -7,7 +7,7 @@ import { onMounted, onUnmounted } from 'vue';
 import EventCard from '@/Components/Bet/EventCard.vue';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
-import { useThrottleFn } from '@vueuse/core'
+import { useThrottleFn } from '@vueuse/core';
 
 const store = useBets();
 const { allBets } = storeToRefs(useBets());

--- a/resources/js/scripts/stores/bets.js
+++ b/resources/js/scripts/stores/bets.js
@@ -101,6 +101,7 @@ export const useBets = defineStore('bets', {
                     team_id: bet.team_id,
                     bet_type: bet.bet_type,
                     sport: this.sport,
+                    over_under: bet.over_under,
                 };
                 return axios.post(route('api.place-bet'), payload);
             });


### PR DESCRIPTION
PR implements:
- added migration to hold the value of `over_under` to know if the user won or lost the over/under in the new command.
- added command to process placed bets to determine the winner.
- added front-end + back-end functionality to save over under values.

PR test instructions:
- run `php artisan:migrate`
- run `php artisan app:determine-event-outcome football` and ensure if outcomes are correctly determined. may not work if there are no scores returned from the odds api since they only allow you to grab scores from the last three days. 
- visit [https://bet-the-boys.test/sport/football](https://bet-the-boys.test/sport/football)
  - place a over/under bet and ensure that the `over_under` column on the `bets` table gets saved.
  - ensure that the bets returned from the request are are only for next sunday if it is not currently sunday. if it is sunday it should only show you bets for that day.

closes: #105 